### PR TITLE
[Fixes #10] Add missing tests about input parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ RemoteWPS1.sln
 /Include
 /Lib/
 /Scripts/
+.eggs/
 
 /RemoteWPS.pyproj
 /RemoteWPS.sln
@@ -18,3 +19,10 @@ RemoteWPS1.sln
 /json_out.json
 /json_out_1.json
 /json_out_2.json
+/copy_of_source_json.json
+
+# Testing output
+.coverage
+
+# IDE
+.idea

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ certifi==2019.9.11
 cffi==1.11.5
 chardet==3.0.4
 colorama==0.3.6
+coverage==4.5.4
 cryptography==2.3.1
 docutils==0.15.2
 enum34==1.1.6
@@ -19,7 +20,6 @@ lazy-object-proxy==1.2.1
 mccabe==0.4.0
 paramiko==2.4.1
 pep8==1.7.1
-pkg-resources==0.0.0
 pkginfo==1.5.0.1
 psutil==5.4.7
 pyasn1==0.4.4


### PR DESCRIPTION
This PR fixes #10 .

The following test have been added:
- tests for `float` inputs
- tests for `datetime` inputs
- tests for `url` inputs
- tests for `copyfile` action
- tests for `create inputs parameters from dictionary`

Notes:
- `coverage==4.5.4` has been added to requirements
- `pkg-resources==0.0.0` has been removed
